### PR TITLE
add pytest to recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About databroker
 ================
 
-Home: https://github.com/NSLS-II/databroker
+Home: https://github.com/bluesky/databroker
 
 Package license: BSD-3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pip
   run:
     - attrs >=16.3.0
-    - blueksy
+    - bluesky
     - boltons
     - cytoolz
     - doct

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  host:
+  build:
     - python
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ requirements:
 
 test:
   requires:
+    - python
     - pytest
   imports:
     - databroker

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/NSLS-II/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/bluesky/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -17,13 +17,12 @@ build:
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  build:
+  host:
     - python
     - pip
-    - pytest
-    - pytest-runner
   run:
     - attrs >=16.3.0
+    - blueksy
     - boltons
     - cytoolz
     - doct
@@ -58,7 +57,7 @@ test:
     - pytest --pyargs {{ name }}.tests
 
 about:
-  home: https://github.com/NSLS-II/databroker
+  home: https://github.com/bluesky/databroker
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -66,7 +65,7 @@ about:
 
   description: 'A unified interface to the various data sources at NSLS-II.'
   doc_url: http://nsls-ii.github.io/databroker/
-  dev_url: https://github.com/NSLS-II/databroker/
+  dev_url: https://github.com/bluesky/databroker/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,15 +46,10 @@ requirements:
     - ujson
 
 test:
-  requires:
-    - python
-    - pytest
   imports:
     - databroker
     - databroker.core
     - databroker.broker
-  commands:
-    - pytest --pyargs {{ name }}.tests
 
 about:
   home: https://github.com/bluesky/databroker

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,15 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  build:
+  host:
     - python
     - pip
+    - pytest
+    - pytest-runner
   run:
     - attrs >=16.3.0
     - boltons
@@ -45,10 +47,14 @@ requirements:
     - ujson
 
 test:
+  requires:
+    - pytest
   imports:
     - databroker
     - databroker.core
     - databroker.broker
+  commands:
+    - pytest --pyargs {{ name }}.tests
 
 about:
   home: https://github.com/NSLS-II/databroker


### PR DESCRIPTION
This PR is to update the `test` field of the recipe to utilize the tests written for the package. Test scripts are found at: https://github.com/bluesky/databroker.

Additionally, the `build` field was changed to `host` and the build number was bumped up.