### PR TITLE
Add a missing "glueviz" requirement to databroker

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,7 +13,6 @@ jobs:
       linux_:
         CONFIG: linux_
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
@@ -26,11 +25,8 @@ jobs:
 
   - script: |
         export CI=azure
-        if [ "$(Build.SourceBranch)" == "refs/heads/$UPLOAD_ON_BRANCH" -a $UPLOAD_PACKAGES == "True" ]; then
-            export UPLOAD_PACKAGES=True
-        else
-            export UPLOAD_PACKAGES=False
-        fi
+        export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+        export UPLOAD_ON_BRANCH="master"
         .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -26,6 +26,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y mesa-libGL
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -64,6 +64,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e GIT_BRANCH \
+           -e UPLOAD_ON_BRANCH \
            -e CI \
            $DOCKER_IMAGE \
            bash \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -24,10 +24,11 @@ requirements:
     - boltons
     - cytoolz
     - doct
+    - glueviz
     - h5py
     - humanize
-    - jsonschema
     - jinja2
+    - jsonschema
     - mongoquery
     - numpy
     - pandas

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+mesa-libGL


### PR DESCRIPTION
I guess it was copied over from [CF's recipe](https://github.com/conda-forge/databroker-feedstock/blob/master/recipe/meta.yaml) without comparison of the dependencies with the recipe from [lightsource2-recipes](https://github.com/NSLS-II/lightsource2-recipes/blob/master/recipes-tag/databroker/meta.yaml). Fixing it here.