### PR TITLE
Fix event-model pin.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
     - boltons
     - dask
     - doct
-    - event-model >=1.11.1
+    - event-model >=1.13.0b4
     - humanize
     - intake >=0.5.2
     - jinja2


### PR DESCRIPTION
Per [this report](https://nikea.slack.com/archives/C7PSB29KK/p1574379999139200) from @prjemian in the databroker channel of the Nikea slack, we need to specify a dependency on a (pre)release of event-model that includes the new `register_coersion` code.